### PR TITLE
drop extra fields/_version_ from Solr's schema.xml

### DIFF
--- a/solr-conf/schema.xml
+++ b/solr-conf/schema.xml
@@ -335,8 +335,6 @@
         unknown fields indexed and/or stored by default -->
    <field name="dc.description" type="text_fgs"  indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*" type="text_fgs"  indexed="true"  stored="true" multiValued="true"/>
-   <field name="_version_" type="long" indexed="true" stored="true"/>
-
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.


### PR DESCRIPTION
## JIRA Ticket: _no applicable ticket_

# What does this Pull Request do?
It drops a extra and unnecessary field definition from Solr's schema.xml

# What's new?
See above.

This extra line throws an error on porter.

# How should this be tested?
Verify that the dropped line (338) is (was) a duplicate of line 289.

# Additional Notes:
n/a

# Interested parties
@pc37utn