### PR TITLE
Address TRAC-878

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -82,6 +82,13 @@
     </field>
   </xsl:template>
 
+  <!-- the following template adds a date_of_award field -->
+  <xsl:template match="mods:mods/mods:genre[@authority='COAR'][text()='thesis']" mode="utk_ir_MODS">
+    <field name="utk_mods_etd_date_of_award_dt">
+      <xsl:value-of select="mods:mods/mods:originInfo/mods:dateIssued[@keyDate='yes'][@encoding='edtf']"/>
+    </field>
+  </xsl:template>
+
   <!-- Handle dates. -->
   <xsl:template match="mods:*[(@type='date') or (contains(translate(local-name(), 'D', 'd'), 'date'))][normalize-space(text())]" mode="slurping_MODS">
     <xsl:param name="prefix"/>

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -84,8 +84,8 @@
 
   <!-- the following template adds a date_of_award field -->
   <xsl:template match="mods:mods/mods:genre[@authority='COAR'][text()='thesis']" mode="utk_ir_MODS">
-    <field name="utk_mods_etd_date_of_award_dt">
-      <xsl:value-of select="mods:mods/mods:originInfo/mods:dateIssued[@keyDate='yes'][@encoding='edtf']"/>
+    <field name="utk_mods_etd_date_of_award_s">
+      <xsl:value-of select="preceding-sibling::mods:originInfo/mods:dateIssued[@keyDate='yes'][@encoding='edtf']"/>
     </field>
   </xsl:template>
 


### PR DESCRIPTION
**JIRA ticket:** [TRAC-878](https://jira.lib.utk.edu/projects/TRAC/issues/TRAC-878)
## What does this do? ##
This PR adds a new Solr field to slurp_all_MODS for date_of_publication. 

## How to test this? ##
1. `git pull --all` on TRACE
2. `vagrant destroy --force` in TRACE
3. in TRACE, `git checkout -b origin/TRAC-882` or `git checkout -b TRAC-882 origin/TRAC-882` or whatever your preferred method.
4. update `TRACE/scripts/custom_scripts/090_update_basic_solr_config.sh`, line 13 with the following (i.e. duplicate the line, comment #13, then update #14):
```
#git -C "$HOME_DIR"/utk-fedora-fedoragsearch-solr-config checkout -b institutional_repository origin/institutional_repository
git -C "$HOME_DIR"/utk-fedora-fedoragsearch-solr-config checkout -b TRAC-878 origin/TRAC-878
```
(this will specify the correct code to deploy as part of `vagrant up`)
5. run `vagrant up`
6. after the VM is a fully armed and operational battlestation, submit a new ETD and remember the PID(!)
7. after submitting, accepting, and publishing (or some variation thereof), visit the following URL: `http://localhost:8080/solr/collection1/select?q=PID%3A%22utk.ir.td%3A__%22&fl=utk_mods_etd*&wt=xml&indent=true`, substituting your PID digits for the underscores.
8. if you do not see `utk_mods_etd_date_of_award_s` in the resulting list, then please let me know!
9. if you do see the `utk_mods_etd_date_of_award_s` in the field list, then we have a success!

## Notes ##
## Interested Parties ##
@cdeaneGit @markpbaggett 

