### PR TITLE
TRAC-886 Add field utk_mods_etd_thesis_advisor

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -55,14 +55,30 @@
     </field>
   </xsl:template>
 
-  <!-- the following template creates an _ms field for thesis advisors -->
-  <xsl:template match="mods:mods/mods:name[(mods:role/mods:roleTerm='Thesis advisor') or (mods:role/mods:roleTerm='thesis advisor')]" mode="utk_ir_MODS">
-    <xsl:variable name="advisor" select="mods:displayForm"/>
 
-    <field name="utk_mods_etd_name_thesis_advisor_ms">
-      <xsl:value-of select="$advisor"/>
-    </field>
-  </xsl:template>
+
+  <!-- the following template creates an _ms field for thesis advisors -->
+  <xsl:template match="mods:mods/mods:name[(mods:role/mods:roleTerm='Thesis advisor') or 
+    (mods:role/mods:roleTerm='thesis advisor')]" mode="utk_ir_MODS">
+
+    <xsl:for-each>
+      <xsl:variable name="given-n" select="mods:namePart[@type='given']"/>
+      <xsl:variable name="family-n" select="mods:namePart[@type='family']"/>
+      <xsl:variable name="t-o-address" select="mods:namePart[@type='termsOfAddress']"/>
+
+      <field name="utk_mods_etd_thesis_advisor_ms">  
+          <xsl:choose>
+             <xsl:when test="$t-o-address!=''">
+                <xsl:value-of select="concat($family-n, ', ', $given-n, ', ', $t-o-address)"/>
+             </xsl:when>
+             <xsl:otherwise>
+                <xsl:value-of select="concat($family-n, ', ', $given-n)"/>
+             </xsl:otherwise>
+          </xsl:choose>
+      </field>
+    </xsl:for-each>
+</xsl:template>
+
 
   <!-- the following template creates an _ms field for committee members -->
   <xsl:template match="mods:mods/mods:name[(mods:role/mods:roleTerm='Committee member') or (mods:role/mods:roleTerm='Committee Member')]" mode="utk_ir_MODS">


### PR DESCRIPTION
NULL AND VOID.
Because conflicts with institutional_repository branch, I created a new branch utk-fedora-fsc(TRAC-866a)
I revised TRACE(TRAC-866) so it would load utk-fedora-fsc(TRAC-886a) for testiing)

utk-fedora-fedoragsearch-solr-config(TRAC-886) was created from
utk-fedora-fedoragsearch-solr-config(instituional-repository)

The file slurp_all_MODS_to_solr.xslt was revised.
A template was made to take care of thesis_advisor(s) and for each thesis_advisor
creates a field utk_mods_etd_thesis_advisor

Please DO NOT test.
@CanOfBees @markpbaggett 