### PR TITLE
Address DR-40.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -73,6 +73,13 @@
     </field>
   </xsl:template>
 
+  <!-- the following template creates a Supplied Title field -->
+  <xsl:template match="mods:mods/mods:titleInfo[@supplied='yes']/mods:title" mode="utk_MODS">
+    <field name="utk_mods_supplied_title_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+
   <!-- the following template creates an archivalCollection+archivalIdentifier _ms field -->
   <xsl:template match="mods:mods/mods:relatedItem[@type='host'][@displayLabel='Collection']" mode="utk_MODS">
     <xsl:variable name="vColl" select="child::mods:titleInfo/mods:title"/>


### PR DESCRIPTION
**JIRA Ticket**: [DR-40](https://jira.lib.utk.edu/browse/DR-40)

## What does this do?

Adds a field for supplied titles to the digital_collections Solr branch

## Why?

The recursion in the out-of-the-box Solr transformations does not capture this data so we can use it as a basis to update fgsLabel on form ingest and also display it separately from titles.

This is necessary because Roth has Provenencial titles and supplied titles that need to be treated separately.

## How do you test?

1. Grab a copy of Islandora vagrant (TRACE is easiest)
2. Clone this repo and branch.
3. If you're using TRACE, copy slurp_all_MODS_to_solr.xslt to the appropriate path (use locate).
4. restart tomcat
5. Overwrite the MODS of an existing object with roth:10's from digital.
6. Update the PID with gsearch.
7. Look at the PID in Solr and see if it has the new field (utk_mods_supplied_title_ms.

## Notes

This is already live on digital.  You could just update a Roth pid with gsearch and check it with Solr.

## Interested Parties

@CanOfBees 
