### PR TITLE
Addressing TRAC-891 Revise slurp_all_MODS_to_solr.xslt to create fiel…

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -108,11 +108,34 @@
 
   <!-- the following template creates an _ms field for committee members -->
   <xsl:template match="mods:mods/mods:name[(mods:role/mods:roleTerm='Committee member') or (mods:role/mods:roleTerm='Committee Member')]" mode="utk_ir_MODS">
-    <xsl:variable name="comm-member" select="mods:displayForm"/>
+	  
+    <xsl:for-each select=".">
 
-    <field name="utk_mods_etd_name_committee_member_ms">
-      <xsl:value-of select="$comm-member"/>
-    </field>
+	<xsl:variable name="given-n" select="mods:namePart[@type='given']"/>
+	<xsl:variable name="family-n" select="mods:namePart[@type='family']"/>
+	<xsl:variable name="t-o-address" select="mods:namePart[@type='termsOfAddress']"/>
+        <xsl:variable name="comm-member" select="mods:displayForm"/>
+
+        <field name="utk_mods_etd_committee_member_ms">
+		<xsl:choose>
+		<xsl:when test="$family-n!=''">
+			<xsl:choose>
+				<xsl:when test="$t-o-address!=''">
+					<xsl:value-of select="concat($family-n, ', ', $given-n, ', ', $t-o-address)"/>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:value-of select="concat($family-n, ', ', $given-n)"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:when>
+		<xsl:otherwise>
+              		<xsl:value-of select="$comm-member"/>
+		</xsl:otherwise>
+		</xsl:choose>
+        </field>
+    
+    </xsl:for-each>
+
   </xsl:template>
 
   <!-- the following template adds a utk_mods_ir_publication field -->


### PR DESCRIPTION
One file in utk-fedora-fedoragsearch-solr-config  (TRAC-891-nova) , slurp_all_MODS_to_solr.xslt,  has been revised to create the field utk_mods_etd_committee_member_ms .  I have tested this in vagrant to show myself that it works.

Cricket steps for testing:

1.  Vagrant home
    http://localhost:8000/

2.  userA submit thesis
    TITLE: 0000TEST userA TRAC-891-nova 
    PID:   utk.ir.td:16

3.  thesis_manager accept, publish

4.  admin browse collection, 
    Update solr index (from PID utk.ir.td:16)
    Admin Client for Fedora Generic Search Service
    http://localhost:8080/fedoragsearch/rest

5.  VIEW LIST OF ALL FEDORA PIDS 
    http://localhost:8080/solr/collection1/select?q=*%3A*&sort=PID+asc&rows=1000000&fl=PID&wt=csv&indent=true
    utk.ir.td:16 is on the list


6.  VIEW RESPONSE HEADER for utk.ir.td:16
    http://localhost:8080/solr/collection1/select?q=PID%3A"utk.ir.td%3A16"&fl=utk_mods_etd*&wt=xml&indent=true

7.  SOLR SCHEMA BROWSER
    http://localhost:8080/solr/#/collection1/schema-browser

Please review.

@CanOfBees @markpbaggett 
