### PR TITLE
Address DIT-1067.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -92,6 +92,13 @@
     </field>
   </xsl:template>
   
+  <xsl:template match="mods:mods/mods:originInfo/mods:dateCreated[@encoding='edtf']" mode="utk_MODS">
+    <xsl:variable name="decade" select="substring(., 1, 3)"/>
+    <field name="utk_mods_dateCreated_decade_s">
+          <xsl:value-of select="concat($decade, '0s')"/>
+    </field>
+  </xsl:template>
+  
   <!-- the following template creates a Supplied Title field -->
   <xsl:template match="mods:mods/mods:titleInfo[@supplied='yes']/mods:title" mode="utk_MODS">
     <field name="utk_mods_supplied_title_ms">


### PR DESCRIPTION
**JIRA Ticket**: [DIT-1067](https://jira.lib.utk.edu/browse/DIT-1067)

# What does this do?
Adds a new Solr field to the Digital Collections solr index to hold decade information based on /mods:mods/mods:originInfo/mods:dateCreated[@encoding="edtf"]

# Should this break anything?
No, since it's in the utk mode, it should only affect other things in the mode with the same xpath (nothing).

# Has it been tested?
Yes, and it's on the server now.

# Interested parties
@CanOfBees 