### PR TITLE
Update _dateCreated_decade from _s to _ms

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -94,7 +94,7 @@
   
   <xsl:template match="mods:mods/mods:originInfo/mods:dateCreated[@encoding='edtf']" mode="utk_MODS">
     <xsl:variable name="decade" select="substring(., 1, 3)"/>
-    <field name="utk_mods_dateCreated_decade_s">
+    <field name="utk_mods_dateCreated_decade_ms">
           <xsl:value-of select="concat($decade, '0s')"/>
     </field>
   </xsl:template>


### PR DESCRIPTION
Allow multiple strings in the `utk_mods_dateCreated_decade_s` field (change field type to `_ms`).

There's no ticket for this.

Interested Parties:
@markpbaggett 