### PR TITLE
Address DIT-1129.

### DIFF
--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -807,7 +807,7 @@
         results. bridger.
     -->
     <lst name="appends">
-      <str name="fq">-PID:islandora\:bookCollection -PID:islandora\:compound_collection -PID:islandora\:root -PID:islandora\:root -PID:islandora\:manuscriptCollection -PID:islandora\:transformCollection -PID:islandora\:newspaper_collection -PID:islandora\:default_transform -PID:islandora\:binary_object_collection -PID:ir\:Citations -PID:digital\:collections -PID:pcard00\:100200 -PID:collections\:mpabaker -PID:collections\:gsmrc -PID:collections\:ascoop -PID:collections\:sanborn -PID:collections\:kefauver -PID:collections\:wwiioh -PID:collections\:volvoices -PID:collections\:heilman -PID:collections\:alumnus -PID:collections\:bass -PID:ascoop\:1507160000 -PID:gsmrc\:wcc -PID:gsmrc\:derris -PID:gsmrc\:wderfilms -PID:gsmrc\:webster -PID:gsmrc\:adams -PID:gsmrc\:kintner -PID:gsmrc\:pcard00 -PID:gsmrc\:50yrcove</str>
+      <str name="fq">-PID:islandora\:bookCollection -PID:islandora\:compound_collection -PID:islandora\:root -PID:islandora\:root -PID:islandora\:manuscriptCollection -PID:islandora\:transformCollection -PID:islandora\:newspaper_collection -PID:islandora\:default_transform -PID:islandora\:binary_object_collection -PID:ir\:Citations -PID:digital\:collections</str>
     </lst>
     <!-- "invariants" are a way of letting the Solr maintainer lock down
          the options available to Solr clients.  Any params values


### PR DESCRIPTION
**Note**: This is already live on Porter.

[DIT-1129](https://jira.lib.utk.edu/browse/DIT-1129)

## What does this do

This removes all collections, subcollections, and other objects that are not content models from being ignored by our Solr config file.

## Why

Since we are using Solr for browse now, we need to let all our collections and sub collections show up in Solr results.  If we don't clicking a collection in Solr browse will not show subcollections that are children.

## But what about collections and subcollections that don't have mods_titleInfo_title_ms or mods_abstract_ms.  Won't these be weird in results?

As of January 4, 2019, all collection objects should have at least a mods_titleInfo_title_ms.  @saltar is adding abstracts right now.

## Interested parties
@CanOfBees 