### PR TITLE
Normalize space around roleTerms in utk_mods_names.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -45,7 +45,7 @@
       <xsl:if test="child::mods:role/mods:roleTerm">
         <xsl:text>(</xsl:text>
         <xsl:for-each select="child::mods:role/mods:roleTerm">
-          <xsl:value-of select="."/>
+          <xsl:value-of select="normalize-space(.)"/>
           <xsl:if test="not(position()=last())">,</xsl:if>
         </xsl:for-each>
         <xsl:text>)</xsl:text>


### PR DESCRIPTION
If space isn't normalized around the roleTerm and there is weird spacing, Solr gets weird.