### PR TITLE
Address DIT-1201: add a tableOfContents field (utk_mods_toc_ms).

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -228,6 +228,13 @@
     </field>
   </xsl:template>
 
+  <!-- add a tableOfContents field -->
+  <xsl:template match="mods:mods/mods:tableOfContents" mode="utk_MODS">
+    <field name="utk_mods_toc_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+
   <!-- Handle dates. -->
   <xsl:template match="mods:*[(@type='date') or (contains(translate(local-name(), 'D', 'd'), 'date'))][normalize-space(text())]" mode="slurping_MODS">
     <xsl:param name="prefix"/>


### PR DESCRIPTION
**JIRA ticket:** [DIT-1201](https://jirautk.atlassian.net/browse/DIT-1201)

## What does this PR do? ##
This adds a new Solr field (`utk_mods_toc_ms`) for MODS records with a `mods:tableOfContents` (e.g. [vanvactor:6603](https://digital.lib.utk.edu/collections/islandora/object/vanvactor:6603)).

## What's new? ##
Added a new template to match `mods:tableOfContents` and create a new field.

## How should this be tested? ##
Review and ask any questions you might have. 

## Additional notes ##
Uh, it's already live (things haven't been reindexed yet).

## Interested Parties ##
@mlhale7 