### PR TITLE
DIT-1213: Address erroneous whitespace in `utk_mods_subject_topic_ms` fields

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -176,7 +176,7 @@
     </xsl:variable>
 
     <field name="utk_mods_subject_topic_ms">
-      <xsl:value-of select="normalize-space(concat(., $vAuthority))"/>
+      <xsl:value-of select="normalize-space(concat(child::mods:topic, $vAuthority))"/>
     </field>
   </xsl:template>
 

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -176,7 +176,7 @@
     </xsl:variable>
 
     <field name="utk_mods_subject_topic_ms">
-      <xsl:value-of select="normalize-space(concat(.,' ',$vAuthority))"/>
+      <xsl:value-of select="normalize-space(concat(., $vAuthority))"/>
     </field>
   </xsl:template>
 


### PR DESCRIPTION
**JIRA ticket:** [DIT-1213](https://jirautk.atlassian.net/browse/DIT-1213)

## What does this PR do? ##
This PR cleans up/corrects the XPath expression in the `utk_mods_subject_topic_ms` field template; i.e. we should be using the `child::topic` for creating the field, not the `.` (self) expression.

## What's new ##
A minor change in the expression in the `concat()` function.

## How should this be tested? ##
Review and let's talk about it. 

## Additional Notes ##
Sorry about this. 

## Interested Parties ##
@markpbaggett @mlhale7 