### PR TITLE
Address DIT-1263: add additional specificity to the `utk_mods` subjec…

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -142,7 +142,7 @@
     note: this is *very* generic; it grabs all mods:subjects with an @authority,
     so we may want to add some specificity in here at some point. maybe.
   -->
-  <xsl:template match="mods:mods/mods:subject[@authority]" mode="utk_MODS">
+  <xsl:template match="mods:mods/mods:subject[@authority][mods:topic]" mode="utk_MODS">
     <!--
        dots = Database of the Smokies
        lcsh = Library of Congress


### PR DESCRIPTION
…t template.

JIRA ticket: [DIT-1263](https://jirautk.atlassian.net/browse/DIT-1263)

## what this does ##
This PR adds an additional predicate (`[mods:topic]`) to our `utk_mods_subject_ms` template - this additional predicate will help differentiate between `mod:subject`s with `topic` vs `geographic` children.

## additional notes 'n' questions ##
What other impacts could this have? What metadata do we have that might be impacted by this kind of change? 

## interested parties ##
@markpbaggett @mlhale7 