### PR TITLE
Address DIT-1272.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/RELS-EXT_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/RELS-EXT_to_solr.xslt
@@ -4,6 +4,7 @@
     xmlns:java="http://xml.apache.org/xalan/java"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:foxml="info:fedora/fedora-system:def/foxml#"
+    xmlns:islandora="http://islandora.ca/ontology/relsext#"
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" exclude-result-prefixes="rdf java">
 
     <xsl:variable name="single_valued_hashset_for_rels_ext" select="java:java.util.HashSet.new()"/>
@@ -81,6 +82,7 @@
       <!-- The method java.util.HashSet.add will return false when the value is
       already in the set. -->
       <xsl:choose>
+        <xsl:when test="starts-with(name(), 'islandora:isSequenceNumberOf')"/>
         <xsl:when
           test="java:add($single_valued_hashset_for_rels_ext, concat($prefix, local-name(), '_', $type, '_s'))">
           <field>


### PR DESCRIPTION
**[JIRA DIT-1272](https://jirautk.atlassian.net/browse/DIT-1272)**

**Problem**:

Our Solr config creates tons of unique fields for every single element.  This is especially bad with compound objects since the community creates XML elements like islandora:isSequenceNumberOfpcard00_100201 for compound objects.

**What does this do**:

This ignores creating new Solr fields for elements that start with isSequenceNumberOf in RELS-EXT files.

**What will this do**:

Allow us to get rid of over 38,000 unique fields in our Solr index for Digital Collections.

**How to test**:

Overwrite the existing transform with this one.
Create or update gsearch for an existing part of a compound object.  
Check the solr document to make sure these fields are gone.

**What to do in production**:

Reindex all our compound objects.  Mark can do this with Whitebread.

**Interested Parties**:

@CanOfBees @DonRichards 