### PR TITLE
Add extent, form, recordContentSource, Digital Collection, and Digita…

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -128,7 +128,50 @@
     </field>
   </xsl:template>
   
-
+  <!-- the following template creates a UTK MODS Extent Field -->
+  <xsl:template match="mods:mods/mods:physicalDescription/mods:extent" mode="utk_MODS">
+    <field name="utk_mods_physicalDescription_extent_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+  
+  <!-- the following template creates a UTK MODS Form Field -->
+  <xsl:template match="mods:mods/mods:physicalDescription/mods:form" mode="utk_MODS">
+    <xsl:choose>
+      <xsl:when test="self::node()[@authority]">
+        <field name="utk_mods_physicalDescription_form_authority_ms">
+          <xsl:value-of select="normalize-space(.)"/>
+        </field>
+      </xsl:when>
+      <xsl:otherwise>
+        <field name="utk_mods_physicalDescription_form_ms">
+          <xsl:value-of select="normalize-space(.)"/>
+        </field>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <!-- the following template creates a UTK MODS Record Source Field -->
+  <xsl:template match="mods:mods/mods:recordInfo/mods:recordContentSource" mode="utk_MODS">
+    <field name="utk_mods_recordInfo_recordContentSource_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+  
+  <!-- the following template creates a UTK MODS Digital Collection Field -->
+  <xsl:template match="mods:mods/mods:relatedItem[@type='host'][@displayLabel='Project']/mods:titleInfo/mods:title" mode="utk_MODS">
+    <field name="utk_mods_relatedItem_host_Project_titleInfo_title_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+  
+  <!-- the following template creates a UTK MODS Digital Collection URL Field -->
+  <xsl:template match="mods:mods/mods:relatedItem[@type='host'][@displayLabel='Project']/mods:location/mods:url" mode="utk_MODS">
+    <field name="utk_mods_relatedItem_host_Project_location_url_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
+  </xsl:template>
+  
   <!-- subjects! -->
   <!-- the following template creates a simplified topical subject _ms field -->
   <!--
@@ -221,7 +264,7 @@
     </field>
   </xsl:template>
   
-  <!-- add utk_mods_typeOfResource_ms  for typeOfResource values-->
+  <!-- add utk_mods_typeOfResource_ms for typeOfResource values-->
   <xsl:template match="mods:mods/mods:typeOfResource" mode="utk_MODS">
     <field name="utk_mods_typeOfResource_ms">
       <xsl:value-of select="normalize-space(.)"/>


### PR DESCRIPTION
**Jira Issue**: [DIT-1281](https://jirautk.atlassian.net/browse/DIT-1281)

## What does this Pull Request do?

This PR addresses the yellow rows in this [spreadsheet](https://docs.google.com/spreadsheets/d/11sPajsVEbIaoTFojrJaAIZWV5d0BlCihGGZmKMKN2AA/edit?usp=sharing). It creates Solr fields for extent, form (with and w/o an authority), recordContentSource, Digital Collection, and Digital Collection URL. Defining these fields will allow us to stop relying on recursive Solr field creation.

## How should this be tested?

A description of what steps someone could take to:

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```

## Additional Notes:

This PR does NOT address subject:temporal as this needs to be incorporated into the rest of the existing transform. Additionally, in our final PR, we are going to need to define geographic subjects in a less fragmentary way than we currently have. Ultimately, line 81 should likely not match particularly on subjects with authorities - we could start broader.

This PR does address one blue row - mods_physicalDescription_form_authority_aat_ms - as I already needed to define form terms that don't have authorities for my work.

## Interested parties

@markpbaggett @CanOfBees