### PR TITLE
Address DIT-1304: add facet fields for subjects

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -202,6 +202,9 @@
             <field name="utk_mods_subject_topic_ms">
               <xsl:value-of select="normalize-space(concat(child::mods:topic, $vAuthority))"/>
             </field>
+            <field name="utk_mods_subject_topic_facet_ms">
+              <xsl:value-of select="normalize-space(child::mods:topic)"/>
+            </field>
           </xsl:when>
           <xsl:when test="self::node()[mods:geographic]">
             <xsl:variable name="vGeo" select="child::mods:geographic"/>
@@ -216,9 +219,15 @@
                 </xsl:otherwise>
               </xsl:choose>
             </field>
+            <field name="utk_mods_geo_facet_ms">
+              <xsl:value-of select="normalize-space(child::mods:geographic)"/>
+            </field>
           </xsl:when>
           <xsl:when test="self::node()[mods:temporal]">
             <field name="utk_mods_subject_temporal_ms">
+              <xsl:value-of select="normalize-space(child::mods:temporal)"/>
+            </field>
+            <field name="utk_mods_subject_temporal_facet_ms">
               <xsl:value-of select="normalize-space(child::mods:temporal)"/>
             </field>
           </xsl:when>
@@ -228,15 +237,24 @@
         <field name="utk_mods_subject_topic_curriculumTopics_ms">
           <xsl:value-of select="normalize-space(concat(child::mods:topic,' ','(','Volunteer Voices',')'))"/>
         </field>
+        <field name="utk_mods_subject_topic_curriculumTopics_facets_ms">
+          <xsl:value-of select="normalize-space(child::mods:topic)"/>
+        </field>
       </xsl:when>
       <xsl:when test="self::node()[@displayLabel='Broad Topics']">
         <field name="utk_mods_subject_topic_broadTopics_ms">
           <xsl:value-of select="normalize-space(concat(child::mods:topic,' ','(','Volunteer Voices',')'))"/>
         </field>
+        <field name="utk_mods_subject_topic_broadTopics_facets_ms">
+          <xsl:value-of select="normalize-space(child::mods:topic)"/>
+        </field>
       </xsl:when>
       <xsl:when test="self::node()[@displayLabel='Tennessee Social Studies K-12 Eras in American History']">
         <field name="utk_mods_subject_topic_socStudiesK12_ms">
           <xsl:value-of select="normalize-space(concat(child::mods:topic,' ','(','Volunteer Voices',')'))"/>
+        </field>
+        <field name="utk_mods_subject_topic_socStudiesK12_facets_ms">
+          <xsl:value-of select="normalize-space(child::mods:topic)"/>
         </field>
       </xsl:when>
       <xsl:otherwise>
@@ -245,9 +263,15 @@
             <field name="utk_mods_subject_topic_ms">
               <xsl:value-of select="normalize-space(child::mods:topic)"/>
             </field>
+            <field name="utk_mods_subject_topic_facets_ms">
+              <xsl:value-of select="normalize-space(child::mods:topic)"/>
+            </field>
           </xsl:when>
           <xsl:when test="self::node()[mods:temporal]">
             <field name="utk_mods_subject_temporal_ms">
+              <xsl:value-of select="normalize-space(child::mods:temporal)"/>
+            </field>
+            <field name="utk_mods_subject_temporal_facets_ms">
               <xsl:value-of select="normalize-space(child::mods:temporal)"/>
             </field>
           </xsl:when>
@@ -263,6 +287,9 @@
                   <xsl:value-of select="$vGeo"/>
                 </xsl:otherwise>
               </xsl:choose>
+            </field>
+            <field name="utk_mods_geo_facet_ms">
+              <xsl:value-of select="normalize-space(child::mods:geographic)"/>
             </field>
           </xsl:when>
         </xsl:choose>


### PR DESCRIPTION
add a corresponding facet field for each possible subject field (i.e. when a subject field is created (or populated), a facet field is created (or populated)).

**Jira Issue**: [DIT-1304](https://jirautk.atlassian.net/browse/DIT-1304)

## What does this Pull Request do?
This adds facet fields for subjects, specifically dropping `\@authority` values from the facet fields.

## What's new?
Several new fields. 

## How should this be tested?

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```
## Additional Notes:
Test with records with a large number of subjects, or things from volvoices, or both?

## Interested parties
@mlhale7 