### PR TITLE
Refine local access condition and placeTerm fields to reflect our MODS.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -405,7 +405,7 @@
     </field>
   </xsl:template>
   
-  <!-- add utk_mods_originInfo_place_placeTerm_text_ms for place terms -->
+  <!-- add utk_mods_originInfo_place_placeTerm_ms for place terms -->
   <xsl:template match="mods:mods/mods:originInfo/mods:place/mods:placeTerm" mode="utk_MODS">
     <field name="utk_mods_originInfo_place_placeTerm_ms">
       <xsl:value-of select="normalize-space(.)"/>

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -9,7 +9,7 @@
   <!-- <xsl:include href="/vhosts/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/config/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>-->
   <!--<xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>-->
   <!-- <xsl:include href="/vhosts/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/config/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/> -->
-  <xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/>
+       <xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/>
   <!-- HashSet to track single-valued fields. -->
   <xsl:variable name="single_valued_hashset" select="java:java.util.HashSet.new()"/>
 
@@ -328,13 +328,11 @@
     </field>
   </xsl:template>
   
-  <!-- add utk_mods_accessCondition_local_ms for Local Access Conditions values-->
+  <!-- add utk_mods_accessCondition_local_ms for values not associated with the type attributes of "use and reproduction" or "restriction on access"-->
   <xsl:template match="mods:mods/mods:accessCondition" mode="utk_MODS">
-    <xsl:if test="self::node()[@type!='use and reproduction' or 'restriction on access'] or self::node()[not(@type)]">
     <field name="utk_mods_accessCondition_local_ms">
       <xsl:value-of select="normalize-space(.)"/>
     </field>
-    </xsl:if>
   </xsl:template>
   
   <!-- add utk_mods_accessCondition_use_and_reproduction_ms for Standardized Rights values-->

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -9,7 +9,7 @@
   <!-- <xsl:include href="/vhosts/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/config/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>-->
   <!--<xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/xslt-date-template.xslt"/>-->
   <!-- <xsl:include href="/vhosts/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/config/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/> -->
-    <xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/>
+  <xsl:include href="/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/manuscript_finding_aid.xslt"/>
   <!-- HashSet to track single-valued fields. -->
   <xsl:variable name="single_valued_hashset" select="java:java.util.HashSet.new()"/>
 
@@ -329,10 +329,12 @@
   </xsl:template>
   
   <!-- add utk_mods_accessCondition_local_ms for Local Access Conditions values-->
-  <xsl:template match="mods:mods/mods:accessCondition[@type='local']" mode="utk_MODS">
+  <xsl:template match="mods:mods/mods:accessCondition" mode="utk_MODS">
+    <xsl:if test="self::node()[@type!='use and reproduction' or 'restriction on access'] or self::node()[not(@type)]">
     <field name="utk_mods_accessCondition_local_ms">
       <xsl:value-of select="normalize-space(.)"/>
     </field>
+    </xsl:if>
   </xsl:template>
   
   <!-- add utk_mods_accessCondition_use_and_reproduction_ms for Standardized Rights values-->
@@ -404,8 +406,8 @@
   </xsl:template>
   
   <!-- add utk_mods_originInfo_place_placeTerm_text_ms for place terms -->
-  <xsl:template match="mods:mods/mods:originInfo/mods:place/mods:placeTerm[@type='text']" mode="utk_MODS">
-    <field name="utk_mods_originInfo_place_placeTerm_text_ms">
+  <xsl:template match="mods:mods/mods:originInfo/mods:place/mods:placeTerm" mode="utk_MODS">
+    <field name="utk_mods_originInfo_place_placeTerm_ms">
       <xsl:value-of select="normalize-space(.)"/>
     </field>
   </xsl:template>


### PR DESCRIPTION
**Jira Issue**: [DIT-1309](https://jirautk.atlassian.net/browse/DIT-1309)

## What does this Pull Request do?

This pull request addresses two issues in our existing slurp_all_MODS_to_solr.xslt. First, our existing transform assumed that all placeTerms (mods:mods/mods:originInfo/mods:place/mods:placeTerm) had a type attribute value of "text", but they do not. This PR removes the type="text" from utk_mods_originInfo_place_placeTerm_ms. Changes were also made to utk_mods_accessCondition_local_ms so that all accessConditions that do not have attributes or have attributes that are not "restrictions on use" or "use and reproduction" display.

## How should this be tested?

A description of what steps someone could take to:

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```


## Additional Notes:

These are the main related tickets under the broader ticket: [DIT-1308](https://jirautk.atlassian.net/browse/DIT-1308) & [META-70](https://jirautk.atlassian.net/browse/META-70)

## Interested parties

@CanOfBees 