### PR TITLE
Add two new solr fields to account for all identifier values.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -356,6 +356,24 @@
     </xsl:if>
   </xsl:template>
   
+  <!-- add utk_mods_identifier_misc_ms for miscellaneous identifier values-->
+  <xsl:template match="mods:mods/mods:identifier" mode="utk_MODS">
+    <xsl:if test="self::node()[not(@type='local')] or self::node()[not(@type='filename')] or self::node()[not(@type='issn')] or self::node()[not(@type='isbn')] or self::node()[not(@type='pid')]">
+      <field name="utk_mods_identifier_misc_ms">
+        <xsl:value-of select="normalize-space(.)"/>
+      </field>
+    </xsl:if>
+  </xsl:template>
+  
+  <!-- add utk_mods_publication_identifier_ms for ISSN or ISBN identifier values-->
+  <xsl:template match="mods:mods/mods:identifier" mode="utk_MODS">
+    <xsl:if test="self::node()[@type='issn'] or self::node()[@type='isbn']">
+      <field name="utk_mods_publication_identifier_ms">
+        <xsl:value-of select="normalize-space(.)"/>
+      </field>
+    </xsl:if>
+  </xsl:template>
+   
   <!-- add utk_mods_language_languageTerm_text_ms for language text -->
   <xsl:template match="mods:mods/mods:language/mods:languageTerm[@type='text']" mode="utk_MODS">
     <field name="utk_mods_language_languageTerm_text_ms">


### PR DESCRIPTION
**Jira Issue**: [DIT-1353](https://jirautk.atlassian.net/browse/DIT-1353)

## What does this Pull Request do?

Currently we have important identifiers that are not present in the metadata display (they are only present in the MODS record). We therefore need to make sure that these identifiers are accounted for in Solr. 

One example of an issue this PR will fix comes from the Thompson collection. Ellie is currently adding identifiers specific to the McClung collection because the metadata states "To use photographs or to order reproductions which belong to the McClung Historical Collection, contact DigitalCollections@knoxlib.org or phone 865 215-8808. Please refer to Image Number and provide a brief description of the photograph." Currently this image number is not in the metadata display, so users are extremely unlikely to reference it.

Another instance of an issue this PR fixes involves ISBNs and ISSNs. These are very useful identifiers that allow published materials to be easily identified, but they are not currently showing up. For collections like the Tennessee Farm News, having the ISSN will also allow us to use Solr searches to define title changes (each "title" has a different ISSN).

In order to address these issues I have kept our Local Identifier field as it is and added a catch-all field for various identifiers as well as a field specifically for ISSNs and ISBNs.

## What's new?

- Solr field: utk_mods_identifier_misc_ms (catch-all)
- Solr field: utk_mods_publication_identifier_ms (ISSNs/ISBNs)

## How should this be tested?

A description of what steps someone could take to:

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```

## Additional Notes:

I've attached a few XML files (as .txt) that contain relevant identifiers (ISBNs, ISSNs, film numbers, historic spc identifiers, etc.). Please use these in vagrant. I believe one review is sufficient for this change, but I'd welcome comments from everyone.

[ISSNidentifier.txt](https://github.com/utkdigitalinitiatives/utk-fedora-fedoragsearch-solr-config/files/4477777/ISSNidentifier.txt)
[ISBNIdentifier.txt](https://github.com/utkdigitalinitiatives/utk-fedora-fedoragsearch-solr-config/files/4477783/ISBNIdentifier.txt)
[knoxgardens_identifiers.txt](https://github.com/utkdigitalinitiatives/utk-fedora-fedoragsearch-solr-config/files/4477784/knoxgardens_identifiers.txt)

## Interested parties

@markpbaggett @CanOfBees 