### PR TITLE
Address DIGITAL-42

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -355,30 +355,24 @@
   </xsl:template>
   
   <!-- add utk_mods_identifier_ms for local identifier values-->
-  <xsl:template match="mods:mods/mods:identifier" mode="utk_MODS">
-    <xsl:if test="self::node()[@type='local'] or self::node()[@type='filename']">
-      <field name="utk_mods_identifier_ms">
-        <xsl:value-of select="normalize-space(.)"/>
-      </field>
-    </xsl:if>
+  <xsl:template match="mods:mods/mods:identifier[@type='local' or @type='filename']" mode="utk_MODS">
+    <field name="utk_mods_identifier_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
   </xsl:template>
   
   <!-- add utk_mods_identifier_misc_ms for miscellaneous identifier values-->
-  <xsl:template match="mods:mods/mods:identifier" mode="utk_MODS">
-    <xsl:if test="self::node()[not(@type='local')] or self::node()[not(@type='filename')] or self::node()[not(@type='issn')] or self::node()[not(@type='isbn')] or self::node()[not(@type='pid')]">
-      <field name="utk_mods_identifier_misc_ms">
-        <xsl:value-of select="normalize-space(.)"/>
-      </field>
-    </xsl:if>
+  <xsl:template match="mods:mods/mods:identifier[not(@type='local') or not(@type='filename') or not(@type='issn') or not(@type='isbn') or not(@type='pid')]" mode="utk_MODS">
+    <field name="utk_mods_identifier_misc_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
   </xsl:template>
   
   <!-- add utk_mods_publication_identifier_ms for ISSN or ISBN identifier values-->
-  <xsl:template match="mods:mods/mods:identifier" mode="utk_MODS">
-    <xsl:if test="self::node()[@type='issn'] or self::node()[@type='isbn']">
-      <field name="utk_mods_publication_identifier_ms">
-        <xsl:value-of select="normalize-space(.)"/>
-      </field>
-    </xsl:if>
+  <xsl:template match="mods:mods/mods:identifier[@type='issn' or @type='isbn']" mode="utk_MODS">
+    <field name="utk_mods_publication_identifier_ms">
+      <xsl:value-of select="normalize-space(.)"/>
+    </field>
   </xsl:template>
    
   <!-- add utk_mods_language_languageTerm_text_ms for language text -->

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -362,7 +362,7 @@
   </xsl:template>
   
   <!-- add utk_mods_identifier_misc_ms for miscellaneous identifier values-->
-  <xsl:template match="mods:mods/mods:identifier[not(@type='local') or not(@type='filename') or not(@type='issn') or not(@type='isbn') or not(@type='pid')]" mode="utk_MODS">
+  <xsl:template match="mods:mods/mods:identifier[not(@type='local') and not(@type='filename') and not(@type='issn') and not(@type='isbn') and not(@type='pid')]" mode="utk_MODS">
     <field name="utk_mods_identifier_misc_ms">
       <xsl:value-of select="normalize-space(.)"/>
     </field>


### PR DESCRIPTION
**Jira Issue**: [DIGITAL-42](https://jirautk.atlassian.net/browse/DIGITAL-42)

## What does this Pull Request do?
This PR adds predicates to the `xsl:template match` instructions for `mods:identifier`s. 

## What's new?
Without predicates, or a similar choose construct, we'll have template match conflicts any time we have multiple `mods:identifier`s in a given record.

## How should this be tested?

A description of what steps someone could take to:

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```


## Additional Notes:
The files under test_records should be sufficient for testing this, particularly agrtfn-10001.xml or archivision-9797.xml.

## Interested parties
@mlhale7
