### PR TITLE
Incorporate Wikidata into authorities for subject transform.

### DIFF
--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -192,6 +192,9 @@
             <xsl:when test="self::node()/@authority='agrovoc'">
               <xsl:value-of select="', (AGROVOC)'"/>
             </xsl:when>
+            <xsl:when test="self::node()/@authority='wikidata'">
+              <xsl:value-of select="', (Wikidata)'"/>
+            </xsl:when>
           </xsl:choose>
          </xsl:variable>
     

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -192,9 +192,6 @@
             <xsl:when test="self::node()/@authority='agrovoc'">
               <xsl:value-of select="', (AGROVOC)'"/>
             </xsl:when>
-            <xsl:when test="self::node()/@authority='wikidata'">
-              <xsl:value-of select="', (Wikidata)'"/>
-            </xsl:when>
           </xsl:choose>
          </xsl:variable>
     

--- a/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/fedoragsearch-transforms/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -232,6 +232,11 @@
               <xsl:value-of select="normalize-space(child::mods:temporal)"/>
             </field>
           </xsl:when>
+          <xsl:when test="self::node()[mods:name]">
+            <field name="utk_mods_subject_name_ms">
+              <xsl:value-of select="concat(normalize-space(child::mods:name/mods:namePart), $vAuthority)"/>
+            </field>
+          </xsl:when>
         </xsl:choose>
       </xsl:when>
       <xsl:when test="self::node()[@displayLabel='Volunteer Voices Curriculum Topics']">


### PR DESCRIPTION
**Jira Issue**: [DIGITAL-789](https://jirautk.atlassian.net/browse/TICKET-NUMBER)

## What does this Pull Request do?

Our existing transform does not include Wikidata as a possible authority. This PR adds this authority. Here's a new record that includes a Wikidata entity - https://digital.lib.utk.edu/collections/islandora/object/mencross%3A142/datastream/MODS/view

## How should this be tested?

A description of what steps someone could take to:

1. Add an object to islandora vagrant
2. Look at its Solr document:  [http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true](http://localhost:8080/solr/collection1/select?q=PID%3A%22test:1%22&fl=*&wt=json&indent=true)
3. If overwriting a transform, replace your transform at this path: /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/
4. Restart tomcat or solr: http://localhost:8080/manager/
5. Update gsearch for your object with curl or python or GUI:

```python

import requests

my_pid = 'test:1'
requests.post(f'http://localhost:8080/fedorafedoragsearch/rest?operation=updateIndex&action=fromPid&value={my_pid}', auth=('fedoraAdmin', 'fedoraAdmin'))

```

## Interested parties

@CanOfBees @mathewjordan 